### PR TITLE
Added authorize_with_ssl_client

### DIFF
--- a/lib/smart_proxy_chef_plugin/chef_api.rb
+++ b/lib/smart_proxy_chef_plugin/chef_api.rb
@@ -4,6 +4,7 @@ require 'smart_proxy_chef_plugin/resources/client'
 module ChefPlugin
   class ChefApi < ::Sinatra::Base
     helpers ::Proxy::Helpers
+    authorize_with_ssl_client
 
     get "/nodes/:fqdn" do
       logger.debug "Showing node #{params[:fqdn]}"

--- a/lib/smart_proxy_chef_plugin/foreman_api.rb
+++ b/lib/smart_proxy_chef_plugin/foreman_api.rb
@@ -5,6 +5,7 @@ module ChefPlugin
   class ForemanApi < ::Sinatra::Base
     helpers ::Proxy::Helpers
     authorize_with_trusted_hosts
+    authorize_with_ssl_client
 
     error Proxy::Error::BadRequest do
       log_halt(400, "Bad request : " + env['sinatra.error'].message )


### PR DESCRIPTION
We have refactored develop proxy and extracted the SSL client cert handling
code. Please review. This is needed only if this plugin uses SSL client
certification verification. If not, please close it.