### PR TITLE
Set the develop branch on the smart-proxy dependency in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'smart_proxy', :git => "https://github.com/theforeman/smart-proxy"
+  gem 'smart_proxy', :git => "https://github.com/theforeman/smart-proxy", :branch => "develop"
 end


### PR DESCRIPTION
Otherwise, `bundle install` fails with "Source does not contain any versions
of
'smart_proxy (>= 0) ruby'"